### PR TITLE
Updated version number in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "helix",
 	"name": "Helix Keybindings",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"minAppVersion": "0.15.0",
 	"description": "Enables Helix keybindings on the editor",
 	"author": "Aldo Acevedo",


### PR DESCRIPTION
The version number in manifest.json was 0.1.6, whereas the latest release is 0.1.7.
This conflict resulted in BRAT not being able to grab the latest release and update accordingly.