### PR TITLE
Tell codemirror-helix to not add drawSelection extension

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -41,7 +41,8 @@ export default class HelixPlugin extends Plugin {
             this.extensions.push(Prec.high(helix({
                 config: {
                     "editor.cursor-shape.insert": this.settings.cursorInInsertMode,
-                }
+                },
+                drawSelection: false
             })));
         }
         await this.saveSettings();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
                 "@eslint/json": "^0.14.0",
                 "@types/node": "^16.11.6",
                 "@typescript-eslint/parser": "^8.48.0",
-                "builtin-modules": "^5.0.0",
-                "codemirror-helix": "^0.5.0",
+                "codemirror-helix": "^0.5.3",
                 "esbuild": "0.17.3",
                 "eslint": "^9.39.1",
                 "eslint-plugin-obsidianmd": "^0.1.9",
@@ -27,9 +26,9 @@
             }
         },
         "node_modules/@codemirror/commands": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
-            "integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.2.tgz",
+            "integrity": "sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -41,31 +40,31 @@
             }
         },
         "node_modules/@codemirror/language": {
-            "version": "6.11.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
-            "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+            "version": "6.12.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
+            "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.23.0",
-                "@lezer/common": "^1.1.0",
+                "@lezer/common": "^1.5.0",
                 "@lezer/highlight": "^1.0.0",
                 "@lezer/lr": "^1.0.0",
                 "style-mod": "^4.0.0"
             }
         },
         "node_modules/@codemirror/search": {
-            "version": "6.5.11",
-            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
-            "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+            "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.0.0",
+                "@codemirror/view": "^6.37.0",
                 "crelt": "^1.0.5"
             }
         },
@@ -75,7 +74,6 @@
             "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@marijn/find-cluster-break": "^1.0.0"
             }
@@ -86,7 +84,6 @@
             "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
                 "crelt": "^1.0.6",
@@ -697,7 +694,6 @@
             "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -711,7 +707,6 @@
             "integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@eslint/core": "^0.17.0",
                 "@eslint/plugin-kit": "^0.4.1",
@@ -809,11 +804,12 @@
             }
         },
         "node_modules/@lezer/common": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz",
-            "integrity": "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+            "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@lezer/highlight": {
             "version": "1.2.3",
@@ -821,16 +817,18 @@
             "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@lezer/common": "^1.3.0"
             }
         },
         "node_modules/@lezer/lr": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.4.tgz",
-            "integrity": "sha512-LHL17Mq0OcFXm1pGQssuGTQFPPdxARjKM8f7GA5+sGtHi0K3R84YaSbmche0+RKWHnCsx9asEe5OWOI4FHfe4A==",
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+            "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@lezer/common": "^1.0.0"
             }
@@ -1005,7 +1003,6 @@
             "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.48.0",
                 "@typescript-eslint/types": "8.48.0",
@@ -1197,7 +1194,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1458,19 +1454,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/builtin-modules": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.0.0.tgz",
-            "integrity": "sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -1549,17 +1532,17 @@
             }
         },
         "node_modules/codemirror-helix": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/codemirror-helix/-/codemirror-helix-0.5.0.tgz",
-            "integrity": "sha512-hI56hf9VGz53H1YvL6H1GC7HtP6te8vX+MsIHaE9J7Q3PQ6KFapKtIRg6lqSH898ikHWpMCPu42r6HJN0IfVLA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/codemirror-helix/-/codemirror-helix-0.5.3.tgz",
+            "integrity": "sha512-+OPLS9NQJdy90Ton3dZreFbZ0MOdy5jisdsePAMnvw2GNdPZFdhgVDdpEC8LGoSEmTaBHASJfQWl/TuG/nDXug==",
             "dev": true,
             "license": "MPL-2.0",
             "peerDependencies": {
                 "@codemirror/commands": "^6.0.0",
                 "@codemirror/language": "^6.0.0",
-                "@codemirror/search": "^6.0.0",
-                "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.0.0"
+                "@codemirror/search": "^6.2.0",
+                "@codemirror/state": "^6.3.0",
+                "@codemirror/view": "^6.22.0"
             }
         },
         "node_modules/color-convert": {
@@ -2012,7 +1995,6 @@
             "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -4060,7 +4042,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5310,7 +5291,6 @@
             "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5325,7 +5305,6 @@
             "integrity": "sha512-fcKOvQD9GUn3Xw63EgiDqhvWJ5jsyZUaekl3KVpGsDJnN46WJTe3jWxtQP9lMZm1LJNkFLlTaWAxK2vUQR+cqw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/eslint-plugin": "8.48.0",
                 "@typescript-eslint/parser": "8.48.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@eslint/json": "^0.14.0",
         "@types/node": "^16.11.6",
         "@typescript-eslint/parser": "^8.48.0",
-        "codemirror-helix": "^0.5.0",
+        "codemirror-helix": "^0.5.3",
         "esbuild": "0.17.3",
         "eslint": "^9.39.1",
         "eslint-plugin-obsidianmd": "^0.1.9",


### PR DESCRIPTION
Update codemirror to 0.5.0 which has the ability to turn this off as Obsidian has already added the extension itself.

This fixes the problem of selection visibility in code blocks.

Closes #14.